### PR TITLE
Fix missing Decimal import

### DIFF
--- a/domain/inventory/models.py
+++ b/domain/inventory/models.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from dataclasses import dataclass, field
+from decimal import Decimal
 from typing import Final, Mapping
 
 from domain.shared.value_objects import IngredientId, Quantity


### PR DESCRIPTION
## Summary
- import Decimal in inventory models

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cffe376948321ae679f2b4d3bed66