### PR TITLE
Fix planner shopping unit output

### DIFF
--- a/web/api/routers/planner.py
+++ b/web/api/routers/planner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Mapping
+from enum import Enum
 
 try:
     from fastapi import APIRouter, Depends, HTTPException
@@ -67,7 +68,7 @@ if APIRouter is not None:  # pragma: no cover - skip when FastAPI unavailable
                     ShoppingItem(
                         ingredient=name,
                         amount=float(qty.amount),
-                        unit=qty.unit.value,
+                        unit=qty.unit.value if isinstance(qty.unit, Enum) else str(qty.unit),
                     )
                 )
         return items


### PR DESCRIPTION
## Summary
- handle Quantity units passed as raw strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d371104648321bb963b69e2992fc9