### PR TITLE
Add recipe cover, card UI and CSV export

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,50 @@
+# Cookmate 接口文档
+
+下表列出了 `web/api` 目录下所有 FastAPI 路由文件中定义的接口。除特殊说明外，均返回 JSON 格式。
+
+## 通用
+
+| 方法 | 路径 | 说明 | 定义文件 |
+| --- | --- | --- | --- |
+| GET | `/ping` | 健康检查 | `web/api/main.py` |
+
+## 菜谱 (`web/api/routers/recipe.py`)
+参数约束：
+- 大类 `category`：主食 / 主菜 / 副菜
+- 烹饪方法 `method`：煎 / 炒 / 煮 / 炸 / 蒸
+- 难度 `difficulty`：低 / 中 / 高 / 中低 / 中高
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/recipes/` | 获取所有菜谱名称 |
+| GET | `/recipes/{name}` | 查看菜谱详情 |
+| POST | `/recipes/` | 新建菜谱，body: `{"name": str, "ingredients": {...}, "steps": [...], "category": str, "method": str, "cover": str, ...}` |
+| PATCH | `/recipes/{name}/difficulty` | 更新难度，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/category` | 更新大类，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/method` | 更新烹饪方法，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/pairing` | 更新搭配建议，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/time_minutes` | 更新制作时长，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/notes` | 更新注意事项，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/tutorial` | 更新教程链接，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/cover` | 更新封面地址，body: `{"value": str}` |
+| PATCH | `/recipes/{name}/ingredients` | 更新食材列表，body: `{"ingredients": {...}}` |
+| DELETE | `/recipes/{name}` | 删除指定名称的菜谱 |
+
+## 库存 (`web/api/routers/inventory.py`)
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/inventory/` | 当前库存列表 |
+| GET | `/inventory/low` | 库存过低的食材 |
+| GET | `/inventory/expiring?days=N` | N 天内过期的食材 |
+| POST | `/inventory/` | 新增或更新库存，body: `{"ingredient": str, "amount": number, "unit": str, "expires_on": "YYYY-MM-DD"}` |
+| DELETE | `/inventory/{ingredient}` | 删除指定食材的库存 |
+
+## 智能筛选 (`web/api/routers/planner.py`)
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/planner/cookable?servings=N` | 根据现有库存列出可做菜谱 |
+| POST | `/planner/shopping` | 生成购物清单，body: `{"recipes": {recipe_id: servings}}` (可选) |
+
+

--- a/DevelopmentV0.3.md
+++ b/DevelopmentV0.3.md
@@ -1,6 +1,6 @@
 # Development Guide (v0.3)
 
-> **目标**：在 v0.2 基础上进一步完善前端界面布局，并为 PlannerService 的高级功能预留接口。
+> **目标**：整理所有 API 接口，并全面开发菜谱、库存、筛选页面的功能与 UI。
 
 > **状态标识** | ✅ 完成并通过测试 | ⬜ 尚未实现 / 未通过
 
@@ -24,11 +24,11 @@ cookmate/
 
 | # | 文件/目录 | 说明 | 完成标志 |
 |---|-----------|------|---------|
-| 1 | `web/frontend/static/index.html` | 优雅导航栏+示例菜谱表格 | ✅ |
+| 1 | `web/frontend/static/index.html` | 新增菜谱/库存表单及购物清单展示 | ✅ |
 | 2 | `web/frontend/main.py` | 暴露静态资源，更新版本号 | ✅ |
-| 3 | `web/api/routers/recipe.py` | 新增删除接口 | ✅ |
-| 4 | `README.md` | 更新路线图与示例菜谱 | ✅ |
-| 5 | `pyproject.toml` | 升级版本到 0.3.1 | ✅ |
+| 3 | `web/api/routers/*.py` | 梳理并统一接口 | ✅ |
+| 4 | `README.md` | 更新路线图与快速开始说明 | ✅ |
+| 5 | `API.md` | 列出所有可用接口 | ✅ |
 
 > **下一步优先级**：在 v0.4 中为 UI 增加动画效果与过渡。
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ $ pip install -e .[dev]
 
 # 4. 运行单元测试
 $ PYTHONPATH=$PWD pytest -q
+
+# 5. 初始化 SQLite 数据库（首次运行）
+$ python scripts/init_db.py
+```
+
+导出或导入菜谱为 CSV：
+
+```bash
+$ python scripts/recipes_csv.py export recipes.csv
+$ python scripts/recipes_csv.py import recipes.csv
 ```
 
 ### 运行 API & 前端
@@ -67,7 +77,7 @@ $ ./scripts/dev.sh
 脚本会自动切换到仓库根目录并分别在 `8000`（API）与 `8001`（前端）端口启动服务，
 按 `Ctrl+C` 退出。
 
-前端页面提供更优雅的导航栏，并支持删除菜谱和库存项。页面底部展示了一份示例菜谱表格供参考。
+前端页面现在内置新增 / 删除菜谱、库存的表单，并可直接生成购物清单，方便体验。
 
 ### CLI 体验
 
@@ -144,7 +154,7 @@ sequenceDiagram
 | -------- | ------------------------ | ------ |
 | **v0.1** | MVP 五大功能 (CLI + SQLite) | ✅ 完成 |
 | **v0.2** | FastAPI + 前端 Demo | ✅ 完成 |
-| **v0.3** | 优化前端 UI 和 PlannerService（智能筛选 & 购物清单优化） | ✅ 完成 |
+| **v0.3** | 整理 API 并完善菜谱/库存/筛选页面功能 | ⏳ 进行中 |
 | **v0.4** | 优化前端 UI 动画 | ⏳ 规划 |
 | **v0.5** | 完善全部功能 | ⏳ 规划 |
 | **v0.6** | Docker 部署 | ⏳ 规划 |

--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 from typing import Mapping
 
 from app.unit_of_work import AbstractUnitOfWork
-from domain.recipe.models import Recipe
+from domain.recipe.models import (
+    Recipe,
+    Category,
+    CookMethod,
+    Difficulty,
+)
 from domain.shared.value_objects import Quantity, RecipeId
 
 ###############################################################################
@@ -92,11 +97,36 @@ class RecipeService:  # noqa: WPS110
                 qty = Quantity.of(amount, unit=ing.default_unit if unit_str == "" else unit_str)  # type: ignore[arg-type]
                 ingredients_map[ing.id] = qty
 
+            meta: dict[str, str] | None = None
+            if metadata is not None:
+                meta = {}
+                if cat := metadata.get("category"):
+                    if cat not in {c.value for c in Category}:
+                        raise ValueError("非法的大类")
+                    meta["category"] = cat
+                if method := metadata.get("method"):
+                    if method not in {m.value for m in CookMethod}:
+                        raise ValueError("非法的烹饪方法")
+                    meta["method"] = method
+                if diff := metadata.get("difficulty"):
+                    if diff not in {d.value for d in Difficulty}:
+                        raise ValueError("非法的难度")
+                    meta["difficulty"] = diff
+                for key in [
+                    "pairing",
+                    "time_minutes",
+                    "notes",
+                    "tutorial",
+                    "cover",
+                ]:
+                    if key in metadata:
+                        meta[key] = metadata[key]
+
             recipe = Recipe(
                 name=name,
                 ingredients=ingredients_map,
                 steps=steps or [],
-                metadata=metadata,
+                metadata=meta,
             )
             uow.recipes.add(recipe)
             # commit 在 UoW __exit__ 中调用
@@ -121,3 +151,62 @@ class RecipeService:  # noqa: WPS110
             if not recipe:
                 raise RecipeNotFoundError(name)
             uow.recipes.remove(recipe.id)
+
+    # ------------------------------------------------------------------
+    # 新增：按菜名获取菜谱及单字段更新
+    # ------------------------------------------------------------------
+
+    def get_by_name(self, name: str) -> Recipe:
+        """获取指定菜谱。"""
+        with self.uow as uow:
+            recipe = uow.recipes.find_by_name(name)
+            if not recipe:
+                raise RecipeNotFoundError(name)
+            return recipe
+
+    def update_metadata_field(self, name: str, key: str, value: str) -> None:
+        """更新 metadata 中的单个字段。"""
+        with self.uow as uow:
+            recipe = uow.recipes.find_by_name(name)
+            if not recipe:
+                raise RecipeNotFoundError(name)
+            meta = dict(recipe.metadata or {})
+            if key == "category" and value not in {c.value for c in Category}:
+                raise ValueError("非法的大类")
+            if key == "method" and value not in {m.value for m in CookMethod}:
+                raise ValueError("非法的烹饪方法")
+            if key == "difficulty" and value not in {d.value for d in Difficulty}:
+                raise ValueError("非法的难度")
+            meta[key] = str(value)
+            updated = Recipe(
+                name=recipe.name,
+                ingredients=recipe.ingredients,
+                steps=recipe.steps,
+                metadata=meta,
+                id=recipe.id,
+            )
+            uow.recipes.update(updated)
+
+    def update_ingredients(self, name: str, ingredient_inputs: IngredientInput) -> None:
+        """替换菜谱食材列表。"""
+        with self.uow as uow:
+            recipe = uow.recipes.find_by_name(name)
+            if not recipe:
+                raise RecipeNotFoundError(name)
+
+            ingredients_map = {}
+            for ing_name, (amount, unit_str) in ingredient_inputs.items():
+                ing = uow.ingredients.find_by_name(ing_name)
+                if not ing:
+                    raise ValueError(f"食材 '{ing_name}' 不存在，请先录入食材")
+                qty = Quantity.of(amount, unit=ing.default_unit if unit_str == "" else unit_str)  # type: ignore[arg-type]
+                ingredients_map[ing.id] = qty
+
+            updated = Recipe(
+                name=recipe.name,
+                ingredients=ingredients_map,
+                steps=recipe.steps,
+                metadata=recipe.metadata,
+                id=recipe.id,
+            )
+            uow.recipes.update(updated)

--- a/domain/recipe/models.py
+++ b/domain/recipe/models.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Mapping, Sequence
 
 from domain.shared.value_objects import (
@@ -36,6 +37,37 @@ from domain.shared.value_objects import (
 # MVP 仅需简单标签；后续可扩展字段（spicy_level, cuisine 等）
 MetaData = Mapping[str, str]
 IngredientMap = Mapping[IngredientId, Quantity]
+
+###############################################################################
+# Metadata Enums
+###############################################################################
+
+class Category(str, Enum):  # noqa: WPS110
+    """菜谱大类枚举."""
+
+    MAIN_STAPLE = "主食"
+    MAIN_DISH = "主菜"
+    SIDE_DISH = "副菜"
+
+
+class CookMethod(str, Enum):  # noqa: WPS110
+    """烹饪方式枚举."""
+
+    PAN = "煎"
+    STIR_FRY = "炒"
+    BOIL = "煮"
+    DEEP_FRY = "炸"
+    STEAM = "蒸"
+
+
+class Difficulty(str, Enum):  # noqa: WPS110
+    """难度等级枚举."""
+
+    LOW = "低"
+    MEDIUM = "中"
+    HIGH = "高"
+    MEDIUM_LOW = "中低"
+    MEDIUM_HIGH = "中高"
 
 ###############################################################################
 # Recipe 聚合根

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,8 @@
+from adapters.repo_sqlite.db import init_db
+from adapters.repo_sqlite.recipe_repo import RecipeORM, RecipeIngredientORM
+from adapters.repo_sqlite.ingredient_repo import IngredientORM
+from adapters.repo_sqlite.inventory_repo import InventoryItemORM
+
+if __name__ == "__main__":
+    init_db(RecipeORM, RecipeIngredientORM, IngredientORM, InventoryItemORM)
+    print("SQLite database initialized ✔")

--- a/scripts/recipes_csv.py
+++ b/scripts/recipes_csv.py
@@ -1,0 +1,77 @@
+import csv
+import json
+from app.unit_of_work import SqlAlchemyUnitOfWork
+from app.services.recipe_service import RecipeService, RecipeAlreadyExistsError
+
+FIELDS = [
+    "name",
+    "category",
+    "method",
+    "difficulty",
+    "pairing",
+    "time_minutes",
+    "notes",
+    "tutorial",
+    "cover",
+    "ingredients",
+    "steps",
+]
+
+
+def export_recipes(csv_path: str = "recipes.csv") -> None:
+    """Export all recipes to a CSV file."""
+    uow = SqlAlchemyUnitOfWork()
+    svc = RecipeService(uow)
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writeheader()
+        for r in svc.list_recipes():
+            meta = r.metadata or {}
+            row = {
+                "name": r.name,
+                "category": meta.get("category", ""),
+                "method": meta.get("method", ""),
+                "difficulty": meta.get("difficulty", ""),
+                "pairing": meta.get("pairing", ""),
+                "time_minutes": meta.get("time_minutes", ""),
+                "notes": meta.get("notes", ""),
+                "tutorial": meta.get("tutorial", ""),
+                "cover": meta.get("cover", ""),
+                "ingredients": json.dumps({
+                    svc.uow.ingredients.get(iid).name: [float(q.amount), q.unit.value]
+                    for iid, q in r.ingredients.items()
+                    if svc.uow.ingredients.get(iid)
+                }, ensure_ascii=False),
+                "steps": json.dumps(list(r.steps), ensure_ascii=False),
+            }
+            writer.writerow(row)
+
+
+def import_recipes(csv_path: str = "recipes.csv") -> None:
+    """Load recipes from a CSV file and store them."""
+    uow = SqlAlchemyUnitOfWork()
+    svc = RecipeService(uow)
+    with open(csv_path, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ingredients = json.loads(row["ingredients"])
+            steps = json.loads(row["steps"])
+            meta = {k: row[k] for k in FIELDS if k not in {"name", "ingredients", "steps"} and row[k]}
+            try:
+                svc.create_recipe(row["name"], ingredients, steps, meta)
+            except RecipeAlreadyExistsError:
+                continue
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Export or import recipes")
+    parser.add_argument("action", choices=["export", "import"])
+    parser.add_argument("csv", nargs="?", default="recipes.csv")
+    args = parser.parse_args()
+
+    if args.action == "export":
+        export_recipes(args.csv)
+    else:
+        import_recipes(args.csv)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -54,9 +54,40 @@ def test_recipe_endpoints(client):
         "name": "番茄炒蛋",
         "ingredients": {"鸡蛋": [2, ""], "西红柿": [300, "g"]},
         "steps": ["打蛋", "热锅"],
+        "category": "主菜",
+        "method": "炒",
+        "difficulty": "中",
+        "pairing": "米饭",
+        "time_minutes": "10-15min",
+        "notes": "小火慢炒",
+        "tutorial": "http://example.com",
+        "cover": "http://img.example.com/egg.jpg",
     }
     resp = client.post("/recipes/", json=data)
     assert resp.status_code == 201
+
+    resp = client.patch("/recipes/番茄炒蛋/difficulty", json={"value": "中高"})
+    assert resp.status_code == 200
+
+    resp = client.get("/recipes/番茄炒蛋")
+    assert resp.status_code == 200
+    assert resp.json()["metadata"]["difficulty"] == "中高"
+    assert resp.json()["metadata"]["cover"] == "http://img.example.com/egg.jpg"
+
+    resp = client.patch("/recipes/番茄炒蛋/notes", json={"value": "加点糖"})
+    assert resp.status_code == 200
+
+    resp = client.patch("/recipes/番茄炒蛋/cover", json={"value": "http://img.example.com/new.jpg"})
+    assert resp.status_code == 200
+
+    resp = client.get("/recipes/番茄炒蛋")
+    assert resp.json()["metadata"]["cover"] == "http://img.example.com/new.jpg"
+
+    resp = client.patch(
+        "/recipes/番茄炒蛋/ingredients",
+        json={"ingredients": {"鸡蛋": [3, ""], "西红柿": [400, "g"]}},
+    )
+    assert resp.status_code == 200
 
     resp = client.get("/recipes/")
     assert resp.status_code == 200

--- a/web/api/routers/recipe.py
+++ b/web/api/routers/recipe.py
@@ -16,6 +16,7 @@ from app.services.recipe_service import (
     RecipeNotFoundError,
     RecipeService,
 )
+from domain.recipe.models import Recipe, Category, CookMethod, Difficulty
 from app.unit_of_work import AbstractUnitOfWork
 from web.api.deps import get_uow
 
@@ -29,12 +30,53 @@ if APIRouter is not None:  # pragma: no cover - skip when FastAPI unavailable
         name: str
         ingredients: dict[str, tuple[float | int | str, str]]
         steps: list[str] | None = None
+        category: Category | None = None
+        method: CookMethod | None = None
+        difficulty: Difficulty | None = None
+        pairing: str | None = None
+        time_minutes: str | None = None
+        notes: str | None = None
+        tutorial: str | None = None
+        cover: str | None = None
+
+    class MetaField(BaseModel):  # noqa: D401
+        """Single metadata value."""
+
+        value: str
+
+    class IngredientsIn(BaseModel):  # noqa: D401
+        """Replace ingredients."""
+
+        ingredients: dict[str, tuple[float | int | str, str]]
 
     @router.get("/")
     def list_recipes(uow: AbstractUnitOfWork = Depends(get_uow)) -> list[str]:
         """Return names of all recipes."""
         service = RecipeService(uow)
         return [r.name for r in service.list_recipes()]
+
+    def _serialize_recipe(uow: AbstractUnitOfWork, recipe: Recipe) -> dict:
+        with uow as tx:
+            ingredients = {}
+            for iid, qty in recipe.ingredients.items():
+                ing = tx.ingredients.get(iid)
+                name = ing.name if ing else str(iid)
+                ingredients[name] = [float(qty.amount), qty.unit.value]
+        return {
+            "name": recipe.name,
+            "ingredients": ingredients,
+            "steps": list(recipe.steps),
+            "metadata": recipe.metadata or {},
+        }
+
+    @router.get("/{name}")
+    def get_recipe(name: str, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict:
+        svc = RecipeService(uow)
+        try:
+            recipe = svc.get_by_name(name)
+        except RecipeNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        return _serialize_recipe(uow, recipe)
 
     @router.post("/", status_code=201)
     def create_recipe(
@@ -48,6 +90,20 @@ if APIRouter is not None:  # pragma: no cover - skip when FastAPI unavailable
                 name=data.name,
                 ingredient_inputs=data.ingredients,
                 steps=data.steps,
+                metadata={
+                    k: str(v)
+                    for k, v in {
+                        "category": data.category,
+                        "method": data.method,
+                        "difficulty": data.difficulty,
+                        "pairing": data.pairing,
+                        "time_minutes": data.time_minutes,
+                        "notes": data.notes,
+                        "tutorial": data.tutorial,
+                        "cover": data.cover,
+                    }.items()
+                    if v is not None
+                },
             )
         except RecipeAlreadyExistsError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
@@ -65,5 +121,73 @@ if APIRouter is not None:  # pragma: no cover - skip when FastAPI unavailable
         except RecipeNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
         return Response(status_code=204)
+
+    # ---------------------------------------------------------------
+    # 单字段更新接口
+    # ---------------------------------------------------------------
+
+    def _update(name: str, key: str, value: str, uow: AbstractUnitOfWork) -> None:
+        svc = RecipeService(uow)
+        try:
+            svc.update_metadata_field(name, key, value)
+        except RecipeNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+
+    @router.patch("/{name}/category")
+    def set_category(
+        name: str,
+        data: MetaField,
+        uow: AbstractUnitOfWork = Depends(get_uow),
+    ) -> dict[str, str]:
+        _update(name, "category", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/method")
+    def set_method(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "method", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/difficulty")
+    def set_difficulty(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "difficulty", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/pairing")
+    def set_pairing(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "pairing", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/time_minutes")
+    def set_time(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "time_minutes", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/notes")
+    def set_notes(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "notes", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/tutorial")
+    def set_tutorial(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "tutorial", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/cover")
+    def set_cover(name: str, data: MetaField, uow: AbstractUnitOfWork = Depends(get_uow)) -> dict[str, str]:
+        _update(name, "cover", data.value, uow)
+        return {"msg": "ok"}
+
+    @router.patch("/{name}/ingredients")
+    def set_ingredients(
+        name: str,
+        data: IngredientsIn,
+        uow: AbstractUnitOfWork = Depends(get_uow),
+    ) -> dict[str, str]:
+        svc = RecipeService(uow)
+        try:
+            svc.update_ingredients(name, data.ingredients)
+        except RecipeNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        return {"msg": "ok"}
 else:  # pragma: no cover - placeholder
     router = None

--- a/web/frontend/static/index.html
+++ b/web/frontend/static/index.html
@@ -15,6 +15,10 @@
         section.active { display:block; }
         table { border-collapse:collapse; width:100%; margin-top:20px; }
         th, td { border:1px solid #ccc; padding:4px 8px; }
+        .cards { display:flex; flex-wrap:wrap; }
+        .card { border:1px solid #ccc; border-radius:4px; margin:10px; width:180px; overflow:hidden; }
+        .card img { width:100%; height:120px; object-fit:cover; }
+        .card h4 { margin:0; padding:5px; font-size:16px; }
     </style>
 </head>
 <body>
@@ -30,18 +34,33 @@
     </header>
     <section id="recipes" class="active">
         <h2>菜谱</h2>
+        <form id="recipe-form">
+            <input id="recipe-name" placeholder="名称" required />
+            <textarea id="recipe-ingredients" placeholder='{"鸡蛋": [2, "" ]}'></textarea>
+            <textarea id="recipe-steps" placeholder="步骤，每行一个"></textarea>
+            <input id="recipe-cover" placeholder="封面 URL" />
+            <button type="submit">新增</button>
+        </form>
         <button id="load-recipes">加载菜谱</button>
         <ul id="recipes-list"></ul>
     </section>
     <section id="inventory">
         <h2>库存</h2>
+        <form id="inv-form">
+            <input id="inv-name" placeholder="食材" required />
+            <input id="inv-amt" type="number" placeholder="数量" required />
+            <input id="inv-unit" placeholder="单位" required />
+            <button type="submit">添加/更新</button>
+        </form>
         <button id="load-inv">加载库存</button>
         <ul id="inv-list"></ul>
     </section>
     <section id="planner">
         <h2>智能筛选</h2>
         <button id="check-cookable">可做菜</button>
+        <button id="shopping">购物清单</button>
         <ul id="cookable-list"></ul>
+        <ul id="shopping-list"></ul>
     </section>
 
     <script>
@@ -55,10 +74,33 @@
             document.getElementById(id).classList.add('active');
         });
     });
+    document.getElementById('recipe-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const name = document.getElementById('recipe-name').value;
+        const ingredients = document.getElementById('recipe-ingredients').value;
+        const steps = document.getElementById('recipe-steps').value.split('\n');
+        const cover = document.getElementById('recipe-cover').value;
+        await fetch('/recipes/', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({name, ingredients: JSON.parse(ingredients || '{}'), steps, cover})
+        });
+        document.getElementById('load-recipes').click();
+    });
     document.getElementById('load-recipes').addEventListener('click', async () => {
-        const resp = await fetch('/recipes/');
-        const data = await resp.json();
-        document.getElementById('recipes-list').innerHTML = data.map(r => `<li>${r} <button data-r="${r}">删除</button></li>`).join('');
+        const names = await (await fetch('/recipes/')).json();
+        const byCat = {};
+        for (const n of names) {
+            const d = await (await fetch(`/recipes/${n}`)).json();
+            const cat = d.metadata.category || '其他';
+            byCat[cat] = byCat[cat] || [];
+            byCat[cat].push(d);
+        }
+        const html = Object.entries(byCat).map(([cat, list]) => {
+            const cards = list.map(r => `<div class="card"><img src="${r.metadata.cover || ''}" alt=""><h4>${r.name}</h4><button data-r="${r.name}">删除</button></div>`).join('');
+            return `<h3>${cat}</h3><div class="cards">${cards}</div>`;
+        }).join('');
+        document.getElementById('recipes-list').innerHTML = html;
     });
     document.getElementById('recipes-list').addEventListener('click', async (e) => {
         if (e.target.tagName === 'BUTTON') {
@@ -66,6 +108,18 @@
             const resp = await fetch(`/recipes/${name}`, {method: 'DELETE'});
             if (resp.status === 204) e.target.parentElement.remove();
         }
+    });
+    document.getElementById('inv-form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const ingredient = document.getElementById('inv-name').value;
+        const amount = document.getElementById('inv-amt').value;
+        const unit = document.getElementById('inv-unit').value;
+        await fetch('/inventory/', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ingredient, amount, unit})
+        });
+        document.getElementById('load-inv').click();
     });
     document.getElementById('load-inv').addEventListener('click', async () => {
         const resp = await fetch('/inventory/');
@@ -83,6 +137,11 @@
         const resp = await fetch('/planner/cookable');
         const data = await resp.json();
         document.getElementById('cookable-list').innerHTML = data.map(r => `<li>${r}</li>`).join('');
+    });
+    document.getElementById('shopping').addEventListener('click', async () => {
+        const resp = await fetch('/planner/shopping', {method: 'POST', body: '{}', headers:{'Content-Type':'application/json'}});
+        const data = await resp.json();
+        document.getElementById('shopping-list').innerHTML = data.map(i => `<li>${i.ingredient}: ${i.amount} ${i.unit}</li>`).join('');
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- extend recipe metadata with `cover` image
- document new `/recipes/{name}/cover` endpoint
- support cover field in service and router
- update frontend to display recipe cards grouped by category
- provide CSV import/export script for recipes

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2172aaa48321a83333a8a1a18c47